### PR TITLE
CreateReceiptItemUseCase 메서드 분리

### DIFF
--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/service/ReceiptService.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/service/ReceiptService.kt
@@ -1,0 +1,31 @@
+package com.chaw.shopping_note.app.receipt.application.service
+
+import com.chaw.shopping_note.app.receipt.domain.Receipt
+import com.chaw.shopping_note.app.receipt.exception.ReceiptNotFoundException
+import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
+import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptRepository
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ReceiptService (
+    private val receiptRepository: ReceiptRepository,
+    private val receiptItemRepository: ReceiptItemRepository,
+){
+    suspend fun findReceiptWithPermission(receiptId: Long, userId: Long): Receipt {
+        val receipt = receiptRepository.findById(receiptId).awaitSingleOrNull()
+            ?: throw ReceiptNotFoundException(receiptId)
+
+        receipt.validatePermission(userId)
+        return receipt
+    }
+
+    suspend fun updateReceiptTotal(receipt: Receipt) {
+        val receiptItems = receiptItemRepository.findAllByReceiptId(receipt.id!!)
+            .collectList()
+            .awaitSingle()
+        receipt.setTotal(receiptItems)
+        receiptRepository.save(receipt).awaitSingle()
+    }
+}

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/usecase/CreateReceiptItemUseCase.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/usecase/CreateReceiptItemUseCase.kt
@@ -1,34 +1,23 @@
 package com.chaw.shopping_note.app.receipt.application.usecase
 
 import com.chaw.shopping_note.app.receipt.application.dto.CreateReceiptItemRequestDto
-import com.chaw.shopping_note.app.receipt.domain.Receipt
+import com.chaw.shopping_note.app.receipt.application.service.ReceiptService
 import com.chaw.shopping_note.app.receipt.domain.ReceiptItem
-import com.chaw.shopping_note.app.receipt.exception.ReceiptNotFoundException
 import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
-import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptRepository
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class CreateReceiptItemUseCase(
-    private val receiptRepository: ReceiptRepository,
-    private val receiptItemRepository: ReceiptItemRepository
+    private val receiptItemRepository: ReceiptItemRepository,
+    private val receiptService: ReceiptService
 ) {
 
     suspend fun execute(input: CreateReceiptItemRequestDto): ReceiptItem {
-        val receipt = findReceiptWithPermission(input.receiptId, input.userId)
+        val receipt = receiptService.findReceiptWithPermission(input.receiptId, input.userId)
         val receiptItem = createAndSaveReceiptItem(input)
-        updateReceiptTotal(receipt)
+        receiptService.updateReceiptTotal(receipt)
         return receiptItem
-    }
-
-    private suspend fun findReceiptWithPermission(receiptId: Long, userId: Long): Receipt {
-        val receipt = receiptRepository.findById(receiptId).awaitSingleOrNull()
-            ?: throw ReceiptNotFoundException(receiptId)
-
-        receipt.validatePermission(userId)
-        return receipt
     }
 
     private suspend fun createAndSaveReceiptItem(input: CreateReceiptItemRequestDto): ReceiptItem {
@@ -43,13 +32,5 @@ class CreateReceiptItemUseCase(
 
         receiptItemRepository.save(receiptItem).awaitSingle()
         return receiptItem
-    }
-
-    private suspend fun updateReceiptTotal(receipt: Receipt) {
-        val receiptItems = receiptItemRepository.findAllByReceiptId(receipt.id!!)
-            .collectList()
-            .awaitSingle()
-        receipt.setTotal(receiptItems)
-        receiptRepository.save(receipt).awaitSingle()
     }
 }

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/usecase/DeleteReceiptItemUseCase.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/application/usecase/DeleteReceiptItemUseCase.kt
@@ -1,36 +1,35 @@
 package com.chaw.shopping_note.app.receipt.application.usecase
 
 import com.chaw.shopping_note.app.receipt.application.dto.DeleteReceiptItemRequestDto
+import com.chaw.shopping_note.app.receipt.application.service.ReceiptService
+import com.chaw.shopping_note.app.receipt.domain.ReceiptItem
+import com.chaw.shopping_note.app.receipt.exception.ReceiptItemNotFoundException
 import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
-import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptRepository
-import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.stereotype.Service
-import org.springframework.security.access.AccessDeniedException
 
 @Service
 class DeleteReceiptItemUseCase(
-    private val receiptRepository: ReceiptRepository,
-    private val receiptItemRepository: ReceiptItemRepository
+    private val receiptItemRepository: ReceiptItemRepository,
+    private val receiptService: ReceiptService
 ) {
 
     suspend fun execute(input: DeleteReceiptItemRequestDto): Boolean {
-        val receiptItem = receiptItemRepository.findById(input.receiptItemId).awaitSingleOrNull()
-            ?: throw IllegalArgumentException("ReceiptItem not found")
-        val receipt = receiptRepository.findById(receiptItem.receiptId).awaitSingleOrNull()
-            ?: throw IllegalArgumentException("Receipt with id ${receiptItem.receiptId} not found")
-        if (receipt.userId != input.userId) {
-            throw AccessDeniedException("No Permission")
-        }
-
-        receiptItemRepository.delete(receiptItem).awaitSingleOrNull()
-
-        val receiptItems = receiptItemRepository.findAllByReceiptId(receiptItem.receiptId)
-            .collectList()
-            .awaitSingle()
-        receipt.setTotal(receiptItems)
-        receiptRepository.save(receipt).awaitSingle()
-
+        val receiptItem = findReceiptItem(input.receiptItemId)
+        val receipt = receiptService.findReceiptWithPermission(receiptItem.receiptId, input.userId)
+        deleteReceiptItem(receiptItem)
+        receiptService.updateReceiptTotal(receipt)
         return true
+    }
+
+    private suspend fun findReceiptItem(receiptItemId: Long): ReceiptItem {
+        val receiptItem = receiptItemRepository.findById(receiptItemId).awaitSingleOrNull()
+            ?: throw ReceiptItemNotFoundException()
+        return receiptItem
+    }
+
+    private suspend fun deleteReceiptItem(receiptItem: ReceiptItem) {
+        receiptItemRepository.delete(receiptItem).awaitFirstOrNull()
     }
 }

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/domain/Receipt.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/domain/Receipt.kt
@@ -1,5 +1,6 @@
 package com.chaw.shopping_note.app.receipt.domain
 
+import com.chaw.shopping_note.app.receipt.exception.ReceiptAccessDeniedException
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
@@ -32,5 +33,11 @@ data class Receipt(
         val totalPrice = receiptItems.sumOf { it.totalPrice }
         this.totalPrice = totalPrice
         this.totalCount = receiptItems.size
+    }
+
+    fun validatePermission(userId: Long) {
+        if (this.userId != userId) {
+            throw ReceiptAccessDeniedException(this.id!!, userId)
+        }
     }
 }

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptAccessDeniedException.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptAccessDeniedException.kt
@@ -1,0 +1,5 @@
+package com.chaw.shopping_note.app.receipt.exception
+
+import org.springframework.security.access.AccessDeniedException
+
+class ReceiptAccessDeniedException(receiptId: Long, userId: Long) : AccessDeniedException("No Permission to access this receipt $receiptId for user $userId")

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptItemNotFoundException.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptItemNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.chaw.shopping_note.app.receipt.exception
+
+class ReceiptItemNotFoundException : RuntimeException("ReceiptItem not found")

--- a/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptNotFoundException.kt
+++ b/src/main/kotlin/com/chaw/shopping_note/app/receipt/exception/ReceiptNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.chaw.shopping_note.app.receipt.exception
+
+class ReceiptNotFoundException(receiptId: Long) : RuntimeException("Receipt $receiptId not found")

--- a/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/CreateReceiptItemUseCaseTest.kt
+++ b/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/CreateReceiptItemUseCaseTest.kt
@@ -1,32 +1,28 @@
 package com.chaw.shopping_note.app.application.usecase.unit
 
 import com.chaw.shopping_note.app.receipt.application.dto.CreateReceiptItemRequestDto
+import com.chaw.shopping_note.app.receipt.application.service.ReceiptService
 import com.chaw.shopping_note.app.receipt.application.usecase.CreateReceiptItemUseCase
 import com.chaw.shopping_note.app.receipt.domain.Category
 import com.chaw.shopping_note.app.receipt.domain.Receipt
 import com.chaw.shopping_note.app.receipt.domain.ReceiptItem
 import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
-import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptRepository
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.security.access.AccessDeniedException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.LocalDateTime
-import kotlin.test.assertFailsWith
 
 class CreateReceiptItemUseCaseTest {
 
-    private val receiptRepository = mockk<ReceiptRepository>(relaxed = true)
     private val receiptItemRepository = mockk<ReceiptItemRepository>(relaxed = true)
+    private val receiptService = mockk<ReceiptService>(relaxed = true)
 
     private val createReceiptItemUseCase = CreateReceiptItemUseCase(
-        receiptRepository,
-        receiptItemRepository
+        receiptItemRepository,
+        receiptService
     )
 
     @Test
@@ -55,10 +51,10 @@ class CreateReceiptItemUseCaseTest {
             category = Category.FOOD
         )
 
-        coEvery { receiptRepository.findById(receiptId) } returns Mono.just(receipt)
+        coEvery { receiptService.findReceiptWithPermission(receiptId, userId) } returns receipt
+        coEvery { receiptService.updateReceiptTotal(receipt) } just Runs
         coEvery { receiptItemRepository.save(any()) } answers { Mono.just(firstArg<ReceiptItem>()) }
         coEvery { receiptItemRepository.findAllByReceiptId(receiptId) } returns Flux.empty()
-        coEvery { receiptRepository.save(any()) } answers { Mono.just(firstArg()) }
 
         // when
         val result = createReceiptItemUseCase.execute(input)
@@ -68,64 +64,6 @@ class CreateReceiptItemUseCaseTest {
         assertEquals(input.unitPrice * input.quantity, result.totalPrice)
 
         coVerify(exactly = 1) { receiptItemRepository.save(any()) }
-        coVerify(exactly = 1) { receiptRepository.save(any()) }
-    }
-
-    @Test
-    fun `userId가 다르면 AccessDeniedException이 발생한다`() = runTest {
-        // given
-        val receiptId = 1L
-        val userId = 123L
-        val wrongUserId = 999L
-
-        val receipt = Receipt(
-            id = receiptId,
-            userId = userId,
-            storeId = 10L,
-            purchaseAt = LocalDateTime.now(),
-            totalPrice = 0,
-            totalCount = 0,
-            createdAt = LocalDateTime.now()
-        )
-
-        val input = CreateReceiptItemRequestDto(
-            userId = wrongUserId,
-            receiptId = receiptId,
-            productName = "상품1",
-            productCode = "P001",
-            unitPrice = 5000,
-            quantity = 2,
-            category = Category.FOOD
-        )
-
-        coEvery { receiptRepository.findById(receiptId) } returns Mono.just(receipt)
-
-        // when & then
-        assertFailsWith<AccessDeniedException> {
-            createReceiptItemUseCase.execute(input)
-        }
-    }
-
-    @Test
-    fun `receiptId가 잘못되면 IllegalArgumentException이 발생한다`() = runTest {
-        // given
-        val wrongReceiptId = 999L
-
-        val input = CreateReceiptItemRequestDto(
-            userId = 123L,
-            receiptId = wrongReceiptId,
-            productName = "상품1",
-            productCode = "P001",
-            unitPrice = 5000,
-            quantity = 2,
-            category = Category.FOOD
-        )
-
-        coEvery { receiptRepository.findById(wrongReceiptId) } returns Mono.empty()
-
-        // when & then
-        assertFailsWith<IllegalArgumentException> {
-            createReceiptItemUseCase.execute(input)
-        }
+        coVerify(exactly = 1) { receiptService.updateReceiptTotal(any()) }
     }
 }

--- a/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/CreateReceiptItemUseCaseTest.kt
+++ b/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/CreateReceiptItemUseCaseTest.kt
@@ -7,7 +7,11 @@ import com.chaw.shopping_note.app.receipt.domain.Category
 import com.chaw.shopping_note.app.receipt.domain.Receipt
 import com.chaw.shopping_note.app.receipt.domain.ReceiptItem
 import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/DeleteReceiptItemUseCase.kt
+++ b/src/test/kotlin/com/chaw/shopping_note/app/application/usecase/unit/DeleteReceiptItemUseCase.kt
@@ -1,38 +1,35 @@
 package com.chaw.shopping_note.app.application.usecase.unit
 
 import com.chaw.shopping_note.app.receipt.application.dto.DeleteReceiptItemRequestDto
+import com.chaw.shopping_note.app.receipt.application.service.ReceiptService
 import com.chaw.shopping_note.app.receipt.application.usecase.DeleteReceiptItemUseCase
 import com.chaw.shopping_note.app.receipt.domain.Category
 import com.chaw.shopping_note.app.receipt.domain.Receipt
 import com.chaw.shopping_note.app.receipt.domain.ReceiptItem
 import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptItemRepository
-import com.chaw.shopping_note.app.receipt.infrastructure.repository.ReceiptRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.security.access.AccessDeniedException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.LocalDateTime
-import kotlin.test.assertFailsWith
 
 class DeleteReceiptItemUseCaseTest {
 
-    private val receiptRepository = mockk<ReceiptRepository>()
     private val receiptItemRepository = mockk<ReceiptItemRepository>()
+    private val receiptService = mockk<ReceiptService>(relaxed = true)
 
     private val deleteReceiptItemUseCase = DeleteReceiptItemUseCase(
-        receiptRepository,
-        receiptItemRepository
+        receiptItemRepository,
+        receiptService
     )
 
     @BeforeEach
     fun setUp() {
-        coEvery { receiptRepository.save(any()) } answers { Mono.just(firstArg()) }
         coEvery { receiptItemRepository.delete(any()) } answers { Mono.empty() }
     }
 
@@ -67,8 +64,8 @@ class DeleteReceiptItemUseCaseTest {
         )
 
         coEvery { receiptItemRepository.findById(receiptItemId) } returns Mono.just(receiptItem)
-        coEvery { receiptRepository.findById(receiptId) } returns Mono.just(receipt)
         coEvery { receiptItemRepository.findAllByReceiptId(receiptId) } returns Flux.empty()
+        coEvery { receiptService.findReceiptWithPermission(receiptId, userId) } returns receipt
 
         val input = DeleteReceiptItemRequestDto(
             userId = userId,
@@ -82,69 +79,6 @@ class DeleteReceiptItemUseCaseTest {
         assertTrue(result)
 
         coVerify(exactly = 1) { receiptItemRepository.delete(receiptItem) }
-        coVerify(exactly = 1) { receiptRepository.save(any()) }
-    }
-
-    @Test
-    fun `userId가 다르면 AccessDeniedException이 발생한다`() = runTest {
-        // given
-        val receiptId = 1L
-        val receiptItemId = 100L
-        val userId = 123L
-        val wrongUserId = 999L
-
-        val receipt = Receipt(
-            id = receiptId,
-            userId = userId,
-            storeId = 10L,
-            purchaseAt = LocalDateTime.now(),
-            totalPrice = 10000,
-            totalCount = 2,
-            createdAt = LocalDateTime.now()
-        )
-
-        val receiptItem = ReceiptItem(
-            id = receiptItemId,
-            receiptId = receiptId,
-            productName = "상품1",
-            productCode = "P001",
-            unitPrice = 5000,
-            quantity = 2,
-            totalPrice = 10000,
-            category = Category.FOOD,
-            createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
-        )
-
-        coEvery { receiptItemRepository.findById(receiptItemId) } returns Mono.just(receiptItem)
-        coEvery { receiptRepository.findById(receiptId) } returns Mono.just(receipt)
-
-        val input = DeleteReceiptItemRequestDto(
-            userId = wrongUserId,
-            receiptItemId = receiptItemId
-        )
-
-        // when & then
-        assertFailsWith<AccessDeniedException> {
-            deleteReceiptItemUseCase.execute(input)
-        }
-    }
-
-    @Test
-    fun `receiptItemId가 잘못되면 IllegalArgumentException이 발생한다`() = runTest {
-        // given
-        val wrongReceiptItemId = 999L
-
-        coEvery { receiptItemRepository.findById(wrongReceiptItemId) } returns Mono.empty()
-
-        val input = DeleteReceiptItemRequestDto(
-            userId = 123L,
-            receiptItemId = wrongReceiptItemId
-        )
-
-        // when & then
-        assertFailsWith<IllegalArgumentException> {
-            deleteReceiptItemUseCase.execute(input)
-        }
+        coVerify(exactly = 1) { receiptService.updateReceiptTotal(any()) }
     }
 }


### PR DESCRIPTION
- 메서드가 복잡하여 분리
- ReceiptService 클래스 추가하여 공통 코드 추출